### PR TITLE
feat: Add cellToChildren(parent, resolution)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -107,6 +107,29 @@ export function cellToParent(quadbin: Quadbin): Quadbin {
   return parent;
 }
 
+export function cellToChildren(quadbin: Quadbin, resolution: bigint): Quadbin[] {
+  if (resolution < 0 || resolution > 26 || resolution < getResolution(quadbin)) {
+    throw new Error('Invalid resolution');
+  }
+
+  const zoomLevelMask = ~(0x1fn << 52n);
+  const blockRange = 1n << ((resolution - ((quadbin >> 52n) & 0x1fn)) << 1n);
+  const sqrtBlockRange = 1n << (resolution - ((quadbin >> 52n) & 0x1fn));
+  const blockShift = 52n - (resolution << 1n);
+
+  const childBase =
+    ((quadbin & zoomLevelMask) | (resolution << 52n)) & ~((blockRange - 1n) << blockShift);
+
+  const children: Quadbin[] = [];
+  for (let blockRow = 0n; blockRow < sqrtBlockRange; blockRow++) {
+    for (let blockColumn = 0n; blockColumn < sqrtBlockRange; blockColumn++) {
+      children.push(childBase | ((blockRow * sqrtBlockRange + blockColumn) << blockShift));
+    }
+  }
+
+  return children;
+}
+
 export function geometryToCells(geometry, resolution: bigint): Quadbin[] {
   const zoom = Number(resolution);
   return tiles(geometry, {

--- a/src/index.ts
+++ b/src/index.ts
@@ -107,6 +107,9 @@ export function cellToParent(quadbin: Quadbin): Quadbin {
   return parent;
 }
 
+/**
+ * Returns the children of a cell, in row-major order starting from NW and ending at SE.
+ */
 export function cellToChildren(quadbin: Quadbin, resolution: bigint): Quadbin[] {
   if (resolution < 0 || resolution > 26 || resolution < getResolution(quadbin)) {
     throw new Error('Invalid resolution');

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -1,11 +1,13 @@
 import test from 'tape';
 import {
+  cellToBoundary,
   tileToCell,
+  cellToChildren,
   cellToTile,
   cellToParent,
   geometryToCells,
   getResolution,
-  cellToBoundary
+  hexToBigInt
 } from 'quadbin';
 
 import {tileToQuadkey} from './quadkey-utils.js';
@@ -46,6 +48,18 @@ test('Quadbin getParent', async t => {
     t.deepEquals(Number(zoom), tile.z, `zoom correct ${zoom}`);
   }
 
+  t.end();
+});
+
+test('Quadbin getChildren', async t => {
+  const parent = 5224972163924099071n; // res=8
+  t.deepEquals(cellToChildren(parent, 8n), [parent], 'children at resolution + 0');
+  t.deepEquals(
+    cellToChildren(parent, 9n),
+    [5229475712011862015n, 5229475729191731199n, 5229475746371600383n, 5229475763551469567n],
+    'children at resolution + 1'
+  );
+  t.deepEquals(cellToChildren(parent, 10n).length, 16, 'children at resolution + 2');
   t.end();
 });
 

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -52,14 +52,25 @@ test('Quadbin cellToParent', async t => {
 });
 
 test('Quadbin cellToChildren', async t => {
-  const parent = 5224972163924099071n; // res=8
+  const parentTile = { z: 8, x: 59, y: 97 };
+  const parent = tileToCell(parentTile);
+
   t.deepEquals(cellToChildren(parent, 8n), [parent], 'children at resolution + 0');
+
+  // Order is row major, starting from NW and ending at SE.
   t.deepEquals(
-    cellToChildren(parent, 9n),
-    [5229475712011862015n, 5229475729191731199n, 5229475746371600383n, 5229475763551469567n],
+    cellToChildren(parent, 9n).map(cellToTile),
+    [
+      { z: 9, x: 118, y: 194 }, // nw
+      { z: 9, x: 119, y: 194 }, // ne
+      { z: 9, x: 118, y: 195 }, // sw
+      { z: 9, x: 119, y: 195 }  // se
+    ],
     'children at resolution + 1'
   );
+
   t.deepEquals(cellToChildren(parent, 10n).length, 16, 'children at resolution + 2');
+
   t.end();
 });
 

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -33,7 +33,7 @@ test('Quadbin conversion', async t => {
   t.end();
 });
 
-test('Quadbin getParent', async t => {
+test('Quadbin cellToParent', async t => {
   let tile = {x: 134, y: 1238, z: 10};
   const quadkey = tileToQuadkey(tile);
 
@@ -51,7 +51,7 @@ test('Quadbin getParent', async t => {
   t.end();
 });
 
-test('Quadbin getChildren', async t => {
+test('Quadbin cellToChildren', async t => {
   const parent = 5224972163924099071n; // res=8
   t.deepEquals(cellToChildren(parent, 8n), [parent], 'children at resolution + 0');
   t.deepEquals(


### PR DESCRIPTION
Adds a new utility function, which returns a list of all child cells at a given resolution within a parent cell. 

Usage:

```javascript
const parent = 5224972163924099071n; // res=8
const cells = cellToChildren(parent, 9);
// → 5229475712011862015n, 5229475729191731199n, 5229475746371600383n, 5229475763551469567n
```

Note that `geometryToCells(cellToBoundary(parent), resolution)` will _not_ give the same result, as the conversion to/from a polygon may pick up extra cells at the boundaries due to floating point precision.