### PR TITLE
chore(release): v0.4.0-alpha.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "quadbin",
-  "version": "0.2.0",
+  "version": "0.4.0-alpha.0",
   "description": "Utility functions for working with Quadbins",
   "license": "MIT",
   "type": "module",
@@ -69,5 +69,6 @@
   "volta": {
     "node": "20.18.2",
     "yarn": "4.3.1"
-  }
+  },
+  "stableVersion": "0.3.0"
 }

--- a/scripts/postversion-commit.js
+++ b/scripts/postversion-commit.js
@@ -15,9 +15,9 @@ if (!valid(version)) {
   throw new Error(`Invalid version, "${version}"`);
 }
 
-// Check out a branch if cutting a version from 'main'.
+// Check out a branch if cutting a version from 'master'.
 const branch = execSync('git rev-parse --abbrev-ref HEAD').toString().trim();
-if (branch === 'main') {
+if (branch === 'master') {
   execSync(`git checkout -b 'release/${version}'`);
 }
 


### PR DESCRIPTION
Testing the newly-added workflow for publishing to NPM in Github Actions. Most likely not working yet – I think we'll need to add NPM token to the repo secrets and configure the package ownership in NPM.