### PR TITLE
chore(prerelease): v0.4.0-alpha.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Decodes an string into an index. Inverse of `bigIntToHex()`.
 ## getResolution
 
 ```javascript
-function getResolution(quadbin: bigint): bigint 
+function getResolution(quadbin: bigint): bigint
 ```
 
 Calculates the resolution of a quadbin cell.
@@ -52,7 +52,7 @@ Calculates the resolution of a quadbin cell.
 ## function cellToParent
 
 ```javascript
-function cellToParent(quadbin: bigint): bigint 
+function cellToParent(quadbin: bigint): bigint
 ```
 
 Calculates the parent cell.
@@ -63,8 +63,7 @@ Calculates the parent cell.
 function cellToChildren(quadbin: bigint, resolution: bigint): bigint[]
 ```
 
-Calculates the child cells at given resolution. Results returned in
-row-major order starting from NW and ending at SE.
+Calculates the child cells at given resolution.
 
 ## tileToCell
 
@@ -77,7 +76,7 @@ Converts a xyz tile into a quadbin cell.
 ## cellToTile
 
 ```javascript
-function cellToTile(quadbin: bigint): Tile 
+function cellToTile(quadbin: bigint): Tile
 ```
 
 Converts quadbin cell into a xyz tile.
@@ -85,13 +84,13 @@ Converts quadbin cell into a xyz tile.
 ## geometryToCells
 
 ```javascript
-function geometryToCells(geometry: GeoJSONGeometry, resolution: bigint): bigint 
+function geometryToCells(geometry: GeoJSONGeometry, resolution: bigint): bigint
 ```
 
 ## cellToBoundary
 
 ```javascript
-function cellToBoundary(quadbin: Quadbin): Polygon 
+function cellToBoundary(quadbin: Quadbin): Polygon
 ```
 
 Converts a Quadbin cell identifier into a geographical boundary represented as a polygon

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "quadbin",
-  "version": "0.2.0",
+  "version": "0.4.0-alpha.1",
   "description": "Utility functions for working with Quadbins",
   "license": "MIT",
   "type": "module",
@@ -27,7 +27,7 @@
     "url": "https://github.com/CartoDB/quadbin-js.git"
   },
   "scripts": {
-    "clean": "rm -rf \"dist/*\"",
+    "clean": "rm -rf dist/* || true",
     "build": "microbundle --name quadbin --format cjs,modern,umd --no-compress",
     "build:watch": "microbundle watch --name quadbin --format cjs,modern,umd --no-compress",
     "lint": "prettier --check src",
@@ -66,8 +66,5 @@
     "@math.gl/web-mercator": "^4.1.0"
   },
   "packageManager": "yarn@4.3.1",
-  "volta": {
-    "node": "20.18.2",
-    "yarn": "4.3.1"
-  }
+  "stableVersion": "0.3.0"
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "quadbin",
-  "version": "0.4.0-alpha.1",
+  "version": "0.4.0-alpha.2",
   "description": "Utility functions for working with Quadbins",
   "license": "MIT",
   "type": "module",
@@ -40,6 +40,12 @@
     "prepublish": "yarn lint && yarn test",
     "prepack": "yarn clean && yarn build"
   },
+  "files": [
+    "dist",
+    "src",
+    "README.md",
+    "LICENSE.md"
+  ],
   "browser": {
     "jsdom": false
   },

--- a/scripts/postversion-commit.js
+++ b/scripts/postversion-commit.js
@@ -15,9 +15,9 @@ if (!valid(version)) {
   throw new Error(`Invalid version, "${version}"`);
 }
 
-// Check out a branch if cutting a version from 'main'.
+// Check out a branch if cutting a version from 'master'.
 const branch = execSync('git rev-parse --abbrev-ref HEAD').toString().trim();
-if (branch === 'main') {
+if (branch === 'master') {
   execSync(`git checkout -b 'release/${version}'`);
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -108,7 +108,10 @@ export function cellToParent(quadbin: Quadbin): Quadbin {
 }
 
 /**
- * Returns the children of a cell, in row-major order starting from NW and ending at SE.
+ * Returns the children of a cell.
+ *
+ * @privateRemarks Order of the child cells would, preferably, be
+ *  row-major starting from NW and ending at SE.
  */
 export function cellToChildren(quadbin: Quadbin, resolution: bigint): Quadbin[] {
   if (resolution < 0 || resolution > 26 || resolution < getResolution(quadbin)) {


### PR DESCRIPTION
Changes:

- Remove documentation of cellToChildren order, which was incorrect
- Minor fixes for build and publish scripts
- Publish an alpha release