### PR TITLE
chore(ci): Assign appdev team for dependabot reviews

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+version: 2
+updates:
+  - package-ecosystem: 'npm'
+    directory: '/'
+    schedule:
+      interval: 'monthly'
+    reviewers:
+      - 'CartoDB/app-dev-builder-team'
+    groups:
+      prod:
+        patterns:
+          - '@mapbox/*'
+          - '@math.gl/*'
+          - '@types/mapbox*'
+      dev:
+        dependency-type: 'development'


### PR DESCRIPTION
- monthly non-security dependency updates
- assign app-dev team for reviews
- add dependabot update groups for prod and dev