### PR TITLE
chore(deps): Set dependabot to ignore @mapbox/tile-cover updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,3 +14,7 @@ updates:
           - '@types/mapbox*'
       dev:
         dependency-type: 'development'
+    ignore:
+      # Update would require workaround for antimeridian:
+      # https://github.com/mapbox/tile-cover/issues/87
+      - dependency-name: '@mapbox/tile-cover'


### PR DESCRIPTION
History:

- https://github.com/CartoDB/quadbin-js/pull/24
- https://github.com/CartoDB/quadbin-js/pull/13
- https://github.com/CartoDB/quadbin-js/commit/bf858d438dc1c83b42aa101158585426eb3b39b1

Cause:

- https://github.com/mapbox/tile-cover/issues/87