### PR TITLE
fix(deps): Inline CommonJS dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "quadbin",
-  "version": "0.4.0",
+  "version": "0.4.1-alpha.0",
   "description": "Utility functions for working with Quadbins",
   "license": "MIT",
   "type": "module",
@@ -72,5 +72,6 @@
   "dependencies": {
     "@math.gl/web-mercator": "^4.1.0"
   },
-  "packageManager": "yarn@4.3.1"
+  "packageManager": "yarn@4.3.1",
+  "stableVersion": "0.4.0"
 }

--- a/package.json
+++ b/package.json
@@ -50,11 +50,13 @@
     "jsdom": false
   },
   "devDependencies": {
+    "@mapbox/tile-cover": "3.0.1",
     "@types/geojson": "^7946.0.15",
     "@types/mapbox__tile-cover": "^3.0.4",
     "@types/semver": "^7",
     "microbundle": "^0.15.1",
     "prettier": "^3.4.2",
+    "resolve-package-path": "^4.0.3",
     "semver": "^7.6.3",
     "typescript": "^5.7.3",
     "vitest": "^3.0.5"
@@ -68,7 +70,6 @@
     "node >= 18"
   ],
   "dependencies": {
-    "@mapbox/tile-cover": "3.0.1",
     "@math.gl/web-mercator": "^4.1.0"
   },
   "packageManager": "yarn@4.3.1"

--- a/test/esm-dependencies.spec.ts
+++ b/test/esm-dependencies.spec.ts
@@ -1,0 +1,31 @@
+import {expect, test} from 'vitest';
+import {readFile} from 'node:fs/promises';
+import resolvePackagePath from 'resolve-package-path';
+
+test('dependencies support esm', async () => {
+  // Avoid CJS-only dependencies, which cause issues for downstream users.
+  // TODO: After Node.js v22 is the lowest version used in CI, replace the
+  // `new URL(...)` and `resolve-package-path` lookups with the built-in
+  // `module.findPackageJsonPath` in Node.js v22+.
+  const pkgQueue = [new URL('../package.json', import.meta.url).pathname];
+  const pkgVisited = new Set<string>();
+
+  for (const path of pkgQueue) {
+    const pkg = JSON.parse(await readFile(path, 'utf8'));
+
+    expect(
+      pkg.type === 'module' || pkg.exports !== undefined || pkg.module !== undefined,
+      `${pkg.name} must be esm`
+    ).toBeTruthy();
+
+    pkgVisited.add(pkg.name);
+
+    const dependencies = pkg.dependencies ? Object.keys(pkg.dependencies) : [];
+    const peerDependencies = pkg.peerDependencies ? Object.keys(pkg.peerDependencies) : [];
+    for (const dep of [...dependencies, ...peerDependencies]) {
+      if (!pkgVisited.has(dep) && !dep.startsWith('@types/')) {
+        pkgQueue.push(resolvePackagePath(dep, path)!);
+      }
+    }
+  }
+});

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -1,7 +1,4 @@
 import {describe, expect, test} from 'vitest';
-import {readFile} from 'node:fs/promises';
-import {join, resolve} from 'node:path';
-import resolvePackagePath from 'resolve-package-path';
 import {
   cellToBoundary,
   tileToCell,
@@ -35,31 +32,6 @@ const TEST_TILES = [
   {x: 1, y: 2, z: 3, q: 5202361257054699519n},
   {x: 1023, y: 2412, z: 23, q: 5291729562728627583n}
 ];
-
-test('dependencies support esm', async () => {
-  // Avoid CJS-only dependencies, which cause issues for downstream users.
-  // TODO: After Node.js v22 is the lowest version used in CI, replace the
-  // `new URL(...)` and `resolve-package-path` lookups with the built-in
-  // `module.findPackageJsonPath` in Node.js v22+.
-  const pkgQueue = [new URL('../package.json', import.meta.url).pathname];
-  const pkgVisited = new Set<string>();
-
-  for (const path of pkgQueue) {
-    const pkg = JSON.parse(await readFile(path, 'utf8'));
-
-    expect(pkg.type, `${pkg.name} must be esm`).toBe('module');
-
-    pkgVisited.add(pkg.name);
-
-    const dependencies = pkg.dependencies ? Object.keys(pkg.dependencies) : [];
-    const peerDependencies = pkg.peerDependencies ? Object.keys(pkg.peerDependencies) : [];
-    for (const dep of [...dependencies, ...peerDependencies]) {
-      if (!pkgVisited.has(dep)) {
-        pkgQueue.push(resolvePackagePath(dep, path)!);
-      }
-    }
-  }
-});
 
 describe('tileToCell', () => {
   test.each(TEST_TILES)('%s', ({x, y, z, q}) => {

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -37,6 +37,7 @@ const TEST_TILES = [
 ];
 
 test('dependencies support esm', async () => {
+  // Avoid CJS-only dependencies, which cause issues for downstream users.
   // TODO: After Node.js v22 is the lowest version used in CI, replace the
   // `new URL(...)` and `resolve-package-path` lookups with the built-in
   // `module.findPackageJsonPath` in Node.js v22+.

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -1,4 +1,7 @@
 import {describe, expect, test} from 'vitest';
+import {readFile} from 'node:fs/promises';
+import {join, resolve} from 'node:path';
+import resolvePackagePath from 'resolve-package-path';
 import {
   cellToBoundary,
   tileToCell,
@@ -6,8 +9,7 @@ import {
   cellToTile,
   cellToParent,
   geometryToCells,
-  getResolution,
-  hexToBigInt
+  getResolution
 } from 'quadbin';
 
 import {tileToQuadkey} from './quadkey-utils.js';
@@ -33,6 +35,30 @@ const TEST_TILES = [
   {x: 1, y: 2, z: 3, q: 5202361257054699519n},
   {x: 1023, y: 2412, z: 23, q: 5291729562728627583n}
 ];
+
+test('dependencies support esm', async () => {
+  // TODO: After Node.js v22 is the lowest version used in CI, replace the
+  // `new URL(...)` and `resolve-package-path` lookups with the built-in
+  // `module.findPackageJsonPath` in Node.js v22+.
+  const pkgQueue = [new URL('../package.json', import.meta.url).pathname];
+  const pkgVisited = new Set<string>();
+
+  for (const path of pkgQueue) {
+    const pkg = JSON.parse(await readFile(path, 'utf8'));
+
+    expect(pkg.type, `${pkg.name} must be esm`).toBe('module');
+
+    pkgVisited.add(pkg.name);
+
+    const dependencies = pkg.dependencies ? Object.keys(pkg.dependencies) : [];
+    const peerDependencies = pkg.peerDependencies ? Object.keys(pkg.peerDependencies) : [];
+    for (const dep of [...dependencies, ...peerDependencies]) {
+      if (!pkgVisited.has(dep)) {
+        pkgQueue.push(resolvePackagePath(dep, path)!);
+      }
+    }
+  }
+});
 
 describe('tileToCell', () => {
   test.each(TEST_TILES)('%s', ({x, y, z, q}) => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4995,6 +4995,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"path-root-regex@npm:^0.1.0":
+  version: 0.1.2
+  resolution: "path-root-regex@npm:0.1.2"
+  checksum: 10c0/27651a234f280c70d982dd25c35550f74a4284cde6b97237aab618cb4b5745682d18cdde1160617bb4a4b6b8aec4fbc911c4a2ad80d01fa4c7ee74dae7af2337
+  languageName: node
+  linkType: hard
+
+"path-root@npm:^0.1.1":
+  version: 0.1.1
+  resolution: "path-root@npm:0.1.1"
+  dependencies:
+    path-root-regex: "npm:^0.1.0"
+  checksum: 10c0/aed5cd290df84c46c7730f6a363e95e47a23929b51ab068a3818d69900da3e89dc154cdfd0c45c57b2e02f40c094351bc862db70c2cb00b7e6bd47039a227813
+  languageName: node
+  linkType: hard
+
 "path-scurry@npm:^1.11.1":
   version: 1.11.1
   resolution: "path-scurry@npm:1.11.1"
@@ -5553,6 +5569,7 @@ __metadata:
     "@types/semver": "npm:^7"
     microbundle: "npm:^0.15.1"
     prettier: "npm:^3.4.2"
+    resolve-package-path: "npm:^4.0.3"
     semver: "npm:^7.6.3"
     typescript: "npm:^5.7.3"
     vitest: "npm:^3.0.5"
@@ -5691,6 +5708,15 @@ __metadata:
   version: 5.0.0
   resolution: "resolve-from@npm:5.0.0"
   checksum: 10c0/b21cb7f1fb746de8107b9febab60095187781137fd803e6a59a76d421444b1531b641bba5857f5dc011974d8a5c635d61cec49e6bd3b7fc20e01f0fafc4efbf2
+  languageName: node
+  linkType: hard
+
+"resolve-package-path@npm:^4.0.3":
+  version: 4.0.3
+  resolution: "resolve-package-path@npm:4.0.3"
+  dependencies:
+    path-root: "npm:^0.1.1"
+  checksum: 10c0/d2e7883a075b21fbf084f7615f9201e4d5aea6c22ba670dc66503a256c5eba5983d0822b9d51ef33303bfe9b0025916f622f6d780c42d7c020d826f8a9bc58fa
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Moves `@mapbox/tile-cover` to devDependencies, which is understood by the build system to mean the dependency should be inlined with the build. The dependency is old (last updated 8 years ago), and only includes CommonJS support, but I haven't been able to find any open source alternatives.

The lack of ESM support has become an issue elsewhere, for deck.gl in https://github.com/visgl/deck.gl/issues/7735, and for `@carto/api-client` the CJS dependencies here are breaking our Web Worker support in Vite.

Also includes a unit test to check that all top-level and transient dependencies are ESM moving forward.